### PR TITLE
noteの1文字目の経過時間が長くなるバグの修正

### DIFF
--- a/server/nd/user/typing.html
+++ b/server/nd/user/typing.html
@@ -248,6 +248,7 @@ function start_timer() {
       problem_a = problem.split("");
       elem_untyped.innerHTML = e_untyped.replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\n/g,'<br>').replace(/ /g,'&nbsp;');
       changeColor();
+      time_a = performance.now()
       startR();
     }
   }
@@ -345,14 +346,9 @@ function typeGame(evt) {
 }
 
 function missType() {
-  if (t_cnt == 0) {
-    time_a = performance.now();
-    time[t_cnt] = [key + "x" , Math.round(time_a)/1000];
-  } else {
-    time_b = performance.now();
-    time[t_cnt] = [key + "x" , Math.round(time_b - time_a)/1000];
-    time_a = time_b;
-  }
+  time_b = performance.now();
+  time[t_cnt] = [key + "x" , Math.round(time_b - time_a)/1000];
+  time_a = time_b;
   t_cnt++;
 
   miss_a += key;
@@ -363,14 +359,9 @@ function missType() {
 }
 
 function outputTime() {
-  if (t_cnt == 0){
-    time_a = performance.now();
-    time[t_cnt] = [ key ,Math.round(time_a)/1000];
-  } else {
-    time_b = performance.now();
-    time[t_cnt] = [key ,Math.round(time_b - time_a)/1000];
-    time_a = time_b;
-  }
+  time_b = performance.now();
+  time[t_cnt] = [key ,Math.round(time_b - time_a)/1000];
+  time_a = time_b;
   t_cnt++;
 }
 


### PR DESCRIPTION
以前から問題となっていた「noteの1文字目の経過時間が長くなるバグ」を修正しました。
バグの原因を説明します。
note生成時の経過時間の計算にはperformance.now関数が利用されています。
time_aを1文字前ののperformance.now()の値とすると、
`time_b = performance.now();
 passed_time = time_b - time_a;`
のように経過時間を求めています。
ただし、1文字目の経過時間に関しては
`passed_time = performance.now()`
となっており、これがバグの原因です。
このperformance.now関数というのは、htmlページ生成後からの経過時間を返すようなので、上記の記述では1文字目の経過時間はページ生成後からの経過時間となってしまいます。
上記を修正し、1文字目の経過時間はタイピング開始時からの経過時間となるようにしました。